### PR TITLE
(Iced)Coffeescript, nib, index and backend support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,18 +15,20 @@ Usage: serve [options] [dir]
 
 Options:
 
-  -v, --version       output the version number
-  -F, --format <fmt>  specify the log format string
-  -p, --port <port>   specify the port [3000]
-  -H, --hidden        enable hidden file serving
-  -S, --no-stylus     disable stylus rendering
-  -N, --no-nib        disable nib rendering
-  -J, --no-jade       disable jade rendering
-  -C, --no-coffee     disable (Iced)CoffeeScript rendering
-  -I, --no-icons      disable icons
-  -L, --no-logs       disable request logging
-  -D, --no-dirs       disable directory serving
-  -h, --help          output usage information
+  -v, --version        output the version number
+  -F, --format <fmt>   specify the log format string
+  -i, --index <url>    specify the start page
+  -b, --backend <path> specify a backend script exporting a run(server) function
+  -p, --port <port>    specify the port [3000]
+  -H, --hidden         enable hidden file serving
+  -S, --no-stylus      disable stylus rendering
+  -N, --no-nib         disable nib rendering
+  -J, --no-jade        disable jade rendering
+  -C, --no-coffee      disable (Iced)CoffeeScript rendering
+  -I, --no-icons       disable icons
+  -L, --no-logs        disable request logging
+  -D, --no-dirs        disable directory serving
+  -h, --help           output usage information
 
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -20,7 +20,9 @@ Options:
   -p, --port <port>   specify the port [3000]
   -H, --hidden        enable hidden file serving
   -S, --no-stylus     disable stylus rendering
+  -N, --no-nib        disable nib rendering
   -J, --no-jade       disable jade rendering
+  -C, --no-coffee     disable (Iced)CoffeeScript rendering
   -I, --no-icons      disable icons
   -L, --no-logs       disable request logging
   -D, --no-dirs       disable directory serving

--- a/bin/serve
+++ b/bin/serve
@@ -21,6 +21,8 @@ program
   .version('1.1.0')
   .usage('[options] [dir]')
   .option('-F, --format <fmt>', 'specify the log format string', 'dev')
+  .option('-i, --index <url>', 'specify the start page')
+  .option('-b, --backend <path>', 'specify a backend script')
   .option('-p, --port <port>', 'specify the port [3000]', Number, 3000)
   .option('-H, --hidden', 'enable hidden file serving')
   .option('-S, --no-stylus', 'disable stylus rendering')
@@ -44,6 +46,19 @@ server.use(connect.favicon(program.favicon));
 
 // logger
 if (program.logs) server.use(connect.logger(program.format));
+
+if (program.backend) {
+  require(path + '/' + program.backend).run(server);
+}
+
+if (program.index) {
+  server.use(function(req, res, next){
+    if (req.url === '/') {
+      req.url = program.index;
+    }
+    return next();
+  });
+}
 
 // convert .styl to .css to trick stylus.middleware
 if (program.stylus) {

--- a/bin/serve
+++ b/bin/serve
@@ -22,7 +22,7 @@ program
   .usage('[options] [dir]')
   .option('-F, --format <fmt>', 'specify the log format string', 'dev')
   .option('-i, --index <url>', 'specify the start page')
-  .option('-b, --backend <path>', 'specify a backend script')
+  .option('-b, --backend <path>', 'specify a backend script exporting a run(server) function')
   .option('-p, --port <port>', 'specify the port [3000]', Number, 3000)
   .option('-H, --hidden', 'enable hidden file serving')
   .option('-S, --no-stylus', 'disable stylus rendering')

--- a/bin/serve
+++ b/bin/serve
@@ -11,6 +11,7 @@ var resolve = require('path').resolve
   , stylus = require('stylus')
   , nib = require('nib')
   , jade = require('jade')
+  , iced = require('iced-coffee-script')
   , url = require('url')
   , fs = require('fs');
 
@@ -25,6 +26,7 @@ program
   .option('-S, --no-stylus', 'disable stylus rendering')
   .option('-N, --no-nib', 'disable nib rendering')
   .option('-J, --no-jade', 'disable jade rendering')
+  .option('-C, --no-coffee', 'disable (Iced)CoffeeScript rendering')
   .option('-I, --no-icons', 'disable icons')
   .option('-L, --no-logs', 'disable request logging')
   .option('-D, --no-dirs', 'disable directory serving')
@@ -69,16 +71,29 @@ if (program.jade) {
       }
     });
   });
+
+  if (program.nib) {
+    // stylus nib rendering enabled
+    function compile(str, path) {
+      return stylus(str)
+        .set('filename', path)
+        .use(nib());
+    }
+    server.use(stylus.middleware({ src: path, compile: compile }));
+  } else {
+    server.use(stylus.middleware({ src: path }));
+  }
 }
 
-// stylus
-function compile(str, path) {
-  return stylus(str)
-    .set('filename', path)
-    .set('compress', true)
-    .use(nib());
+// coffeescript
+if (program.coffee) {
+  server.use(function(req, res, next){
+    if (!req.url.match(/\.coffee|\.iced$/)) return next();
+    var file = join(path, url.parse(req.url).pathname);
+    res.setHeader('Content-Type', 'application/x-javascript');
+    res.end(iced.compile(fs.readFileSync(file).toString()));
+  });
 }
-server.use(stylus.middleware({ src: path, compile: compile }));
 
 // static files
 server.use(connect.static(path, { hidden: program.hidden }));

--- a/bin/serve
+++ b/bin/serve
@@ -9,6 +9,7 @@ var resolve = require('path').resolve
   , program = require('commander')
   , connect = require('connect')
   , stylus = require('stylus')
+  , nib = require('nib')
   , jade = require('jade')
   , url = require('url')
   , fs = require('fs');
@@ -22,6 +23,7 @@ program
   .option('-p, --port <port>', 'specify the port [3000]', Number, 3000)
   .option('-H, --hidden', 'enable hidden file serving')
   .option('-S, --no-stylus', 'disable stylus rendering')
+  .option('-N, --no-nib', 'disable nib rendering')
   .option('-J, --no-jade', 'disable jade rendering')
   .option('-I, --no-icons', 'disable icons')
   .option('-L, --no-logs', 'disable request logging')
@@ -70,7 +72,13 @@ if (program.jade) {
 }
 
 // stylus
-server.use(stylus.middleware({ src: path }));
+function compile(str, path) {
+  return stylus(str)
+    .set('filename', path)
+    .set('compress', true)
+    .use(nib());
+}
+server.use(stylus.middleware({ src: path, compile: compile }));
 
 // static files
 server.use(connect.static(path, { hidden: program.hidden }));

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     , "stylus": "*"
     , "nib": "*"
     , "jade": "*"
+    , "iced-coffee-script": "*"
     , "commander": "0.6.1"
   }
   , "bin": { "serve": "./bin/serve" }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
     "name": "serve"
-  , "version": "1.1.0"
+  , "version": "1.1.1"
   , "description": "Simple command-line file / directory server built with connect"
   , "keywords": ["static", "server", "connect"]
   , "author": "TJ Holowaychuk <tj@vision-media.ca>"
   , "dependencies": {
       "connect": "2.3.x"
     , "stylus": "*"
+    , "nib": "*"
     , "jade": "*"
     , "commander": "0.6.1"
   }


### PR DESCRIPTION
You can use (Iced)Coffeescript for JS files now, and nib inside your stylus templates.
You can specify and index page - serve will do an internal rewrite to serve it.
You can specify a script to hook into the server for providing a backend, exporting a run(server) function. This can also be an (Iced)Coffeescript.