### PR TITLE
Make self-reported version match package.json

### DIFF
--- a/bin/serve
+++ b/bin/serve
@@ -18,7 +18,7 @@ var resolve = require('path').resolve
 // CLI
 
 program
-  .version('1.2.0')
+  .version(require('../package.json').version)
   .usage('[options] [dir]')
   .option('-F, --format <fmt>', 'specify the log format string', 'dev')
   .option('-p, --port <port>', 'specify the port [3000]', Number, 3000)


### PR DESCRIPTION
The self-reported version string '1.2.0' wasn't updated when 1.3.0 was
released, and rather than hard-coding it again, I load the version from
package.json so that it remains current for any future releases.

Fixes #26.
