### PR TITLE
Add --live (reload) option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,21 +15,23 @@ Usage: serve [options] [dir]
 
 Options:
 
-  -v, --version        output the version number
-  -F, --format <fmt>   specify the log format string
-  -p, --port <port>    specify the port [3000]
-  -f, --favicon <path> serve the given favicon
-  -H, --hidden         enable hidden file serving
-  -C, --cors           allows cross origin access serving
-  -S, --no-stylus      disable stylus rendering
-  -J, --no-jade        disable jade rendering
-      --no-less        disable less css rendering
-  -I, --no-icons       disable icons
-  -L, --no-logs        disable request logging
-  -D, --no-dirs        disable directory serving
-      --compress       gzip or deflate the response
-      --exec <cmd>     execute command on each request
-  -h, --help           output usage information
+  -v, --version          output the version number
+  -F, --format <fmt>     specify the log format string
+  -p, --port <port>      specify the port [3000]
+  -f, --favicon <path>   serve the given favicon
+  -H, --hidden           enable hidden file serving
+  -C, --cors             allows cross origin access serving
+  -S, --no-stylus        disable stylus rendering
+  -J, --no-jade          disable jade rendering
+      --no-less          disable less css rendering
+  -I, --no-icons         disable icons
+  -L, --no-logs          disable request logging
+  -D, --no-dirs          disable directory serving
+      --compress         gzip or deflate the response
+      --live             enable live-reload service')
+      --live-port <port> change live-reload service port [35729]', Number, 35729)
+      --exec <cmd>       execute command on each request
+  -h, --help             output usage information
 ```
 
 ## Examples

--- a/bin/serve
+++ b/bin/serve
@@ -12,6 +12,9 @@ var resolve = require('path').resolve
   , stylus = require('stylus')
   , jade = require('jade')
   , less = require('less-middleware')
+  , tinylr = require('tiny-lr')
+  , livereload = require('connect-livereload')
+  , watch = require('watch')
   , url = require('url')
   , fs = require('fs');
 
@@ -33,6 +36,8 @@ program
   .option('-f, --favicon <path>', 'serve the given favicon')
   .option('-C, --cors', 'allows cross origin access serving')
   .option('    --compress', 'gzip or deflate the response')
+  .option('    --live', 'enable live-reload service')
+  .option('    --live-port <port>', 'change live-reload service port [35729]', Number, 35729)
   .option('    --exec <cmd>', 'execute command on each request')
   .parse(process.argv);
 
@@ -107,6 +112,20 @@ if (program.cors) {
 // compression
 if (program.compress) {
   server.use(connect.compress());
+}
+
+// livereload
+if (program.live) {
+  // Provide service
+  var lrserver = tinylr();
+  lrserver.listen(program.livePort, function() {
+    console.log('\033[90mprovide livereload service on port \033[96m%d\033[0m', program.livePort);
+  });
+  server.use(livereload({ port: program.livePort }));
+  // Watch and notify client
+  watch.watchTree(path, { ignoreDotFiles: !program.hidden }, function(file) {
+    lrserver.changed({ body: { files: [ file ] }});
+  });
 }
 
 // exec command

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     , "jade": "*"
     , "less-middleware": "*"
     , "commander": "0.6.1"
+    , "connect-livereload": "*"
+    , "tiny-lr": "*"
+    , "watch": "*"
   }
   , "bin": { "serve": "./bin/serve" }
 }


### PR DESCRIPTION
Thanks for the serve command.

I added a new option `--live` to enable [livereload](http://livereload.com/) support.

For me it makes also sense to activate it by default, currently it must be enabled by the user. I'm open for feedback here.