### PR TITLE
Add version number for less-middleware dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
       "connect": "2.3.x"
     , "stylus": "*"
     , "jade": "*"
-    , "less-middleware": "*"
+    , "less-middleware": "0.1.x"
     , "commander": "0.6.1"
   }
   , "bin": { "serve": "./bin/serve" }


### PR DESCRIPTION
`npm install -g serve` currently installs 0.2.1-beta of less-middleware.

This breaks the less generation because of: https://github.com/emberfeather/less.js-middleware/pull/88
