### PR TITLE
Add node-sass-middleware to support .scss

### DIFF
--- a/bin/serve
+++ b/bin/serve
@@ -13,7 +13,8 @@ var resolve = require('path').resolve
   , jade = require('jade')
   , less = require('less-middleware')
   , url = require('url')
-  , fs = require('fs');
+  , fs = require('fs')
+  , sass = require('node-sass-middleware');
 
 // CLI
 
@@ -24,8 +25,9 @@ program
   .option('-F, --format <fmt>', 'specify the log format string', 'dev')
   .option('-p, --port <port>', 'specify the port [3000]', Number, 3000)
   .option('-H, --hidden', 'enable hidden file serving')
-  .option('-S, --no-stylus', 'disable stylus rendering')
   .option('-J, --no-jade', 'disable jade rendering')
+  .option('-S, --no-stylus', 'disable stylus rendering')
+  .option('    --no-sass', 'disable sass css rendering')
   .option('    --no-less', 'disable less css rendering')
   .option('-I, --no-icons', 'disable icons')
   .option('-L, --no-logs', 'disable request logging')
@@ -65,6 +67,14 @@ if (program.stylus) {
   });
 }
 
+// convert .scss to .css to trick sass-middleware
+if (program.sass) {
+  server.use(function(req, res, next){
+    req.url = req.url.replace(/\.scss$/, '.css');
+    next();
+  });
+}
+
 // jade
 if (program.jade) {
   server.use(function(req, res, next){
@@ -91,6 +101,16 @@ server.use(stylus.middleware({ src: path }));
 // less
 if (program.less) {
   server.use(less(path));
+}
+
+// sass
+if (program.sass) {
+  server.use(sass({
+    src: path,
+    dest: path,
+    debug: false,
+    outputStyle: 'expanded'
+  }));
 }
 
 // CORS access for files
@@ -132,4 +152,3 @@ if (program.dirs) {
 server.listen(program.port, function () {
   console.log('\033[90mserving \033[36m%s\033[90m on port \033[96m%d\033[0m', path, program.port);
 });
-

--- a/package.json
+++ b/package.json
@@ -1,21 +1,28 @@
 {
-    "name": "serve"
-  , "version": "1.4.0"
-  , "description": "Simple command-line file / directory server built with connect"
-  , "keywords": ["static", "server", "connect"]
-  , "author": "TJ Holowaychuk <tj@vision-media.ca>"
-  , "preferGlobal": true
-  , "homepage": "https://github.com/visionmedia/serve"
-  , "repository": {
-      "type": "git"
-    , "url": "https://github.com/visionmedia/serve.git"
+  "name": "serve",
+  "version": "1.4.0",
+  "description": "Simple command-line file / directory server built with connect",
+  "keywords": [
+    "static",
+    "server",
+    "connect"
+  ],
+  "author": "TJ Holowaychuk <tj@vision-media.ca>",
+  "preferGlobal": true,
+  "homepage": "https://github.com/visionmedia/serve",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/visionmedia/serve.git"
+  },
+  "dependencies": {
+    "commander": "0.6.1",
+    "connect": "2.3.x",
+    "jade": "*",
+    "less-middleware": "0.1.x",
+    "node-sass-middleware": "^0.4.0",
+    "stylus": "*"
+  },
+  "bin": {
+    "serve": "./bin/serve"
   }
-  , "dependencies": {
-      "connect": "2.3.x"
-    , "stylus": "*"
-    , "jade": "*"
-    , "less-middleware": "0.1.x"
-    , "commander": "0.6.1"
-  }
-  , "bin": { "serve": "./bin/serve" }
 }

--- a/package.json
+++ b/package.json
@@ -1,28 +1,22 @@
 {
-  "name": "serve",
-  "version": "1.4.0",
-  "description": "Simple command-line file / directory server built with connect",
-  "keywords": [
-    "static",
-    "server",
-    "connect"
-  ],
-  "author": "TJ Holowaychuk <tj@vision-media.ca>",
-  "preferGlobal": true,
-  "homepage": "https://github.com/visionmedia/serve",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/visionmedia/serve.git"
-  },
-  "dependencies": {
-    "commander": "0.6.1",
-    "connect": "2.3.x",
-    "jade": "*",
-    "less-middleware": "0.1.x",
-    "node-sass-middleware": "^0.4.0",
-    "stylus": "*"
-  },
-  "bin": {
-    "serve": "./bin/serve"
+    "name": "serve"
+  , "version": "1.4.0"
+  , "description": "Simple command-line file / directory server built with connect"
+  , "keywords": ["static", "server", "connect"]
+  , "author": "TJ Holowaychuk <tj@vision-media.ca>"
+  , "preferGlobal": true
+  , "homepage": "https://github.com/visionmedia/serve"
+  , "repository": {
+      "type": "git"
+    , "url": "https://github.com/visionmedia/serve.git"
   }
+  , "dependencies": {
+      "connect": "2.3.x"
+    , "stylus": "*"
+    , "jade": "*"
+    , "less-middleware": "0.1.x"
+    , "node-sass-middleware": "*"
+    , "commander": "0.6.1"
+  }
+  , "bin": { "serve": "./bin/serve" }
 }


### PR DESCRIPTION
Adds support for `.scss` syntax with [node-sass-middleware](https://github.com/sass/node-sass-middleware)