### PR TITLE
More nice looking error output

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,6 +29,7 @@ Options:
   -D, --no-dirs        disable directory serving
       --compress       gzip or deflate the response
       --exec <cmd>     execute command on each request
+      --stack          output stack trace of errors
   -h, --help           output usage information
 ```
 

--- a/bin/serve
+++ b/bin/serve
@@ -34,6 +34,7 @@ program
   .option('-C, --cors', 'allows cross origin access serving')
   .option('    --compress', 'gzip or deflate the response')
   .option('    --exec <cmd>', 'execute command on each request')
+  .option('    --stack', 'print stack trace instead of nice errors')
   .parse(process.argv);
 
 // path
@@ -120,12 +121,23 @@ if (program.exec) {
 server.use(connect.static(path, { hidden: program.hidden }));
 
 // directory serving
-
 if (program.dirs) {
     server.use(connect.directory(path, {
       hidden: program.hidden
     , icons: program.icons
   }));
+}
+
+// error handling
+if (!program.stack) {
+  server.use(function(err, req, res, next){
+    switch (err.name) {
+      case ('EADDRINUSE') {
+        
+      }
+    }
+    next();
+  });
 }
 
 // start the server

--- a/bin/serve
+++ b/bin/serve
@@ -37,10 +37,6 @@ program
   .option('    --stack', 'print stack trace instead of nice errors')
   .parse(process.argv);
 
-var ServerError = function(){
-  
-};
-
 // path
 var path = resolve(program.args.shift() || '.');
 

--- a/bin/serve
+++ b/bin/serve
@@ -34,7 +34,7 @@ program
   .option('-C, --cors', 'allows cross origin access serving')
   .option('    --compress', 'gzip or deflate the response')
   .option('    --exec <cmd>', 'execute command on each request')
-  .option('    --stack', 'print stack trace instead of nice errors')
+  .option('    --stack', 'output stack trace of errors')
   .parse(process.argv);
 
 // path

--- a/bin/serve
+++ b/bin/serve
@@ -37,6 +37,10 @@ program
   .option('    --stack', 'print stack trace instead of nice errors')
   .parse(process.argv);
 
+var ServerError = function(){
+  
+};
+
 // path
 var path = resolve(program.args.shift() || '.');
 
@@ -131,9 +135,9 @@ if (program.dirs) {
 // error handling
 if (!program.stack) {
   server.use(function(err, req, res, next){
-    switch (err.name) {
+    switch (err.code) {
       case ('EADDRINUSE') {
-        
+        console.log('error: port %s is already in use', err.port);
       }
     }
     next();


### PR DESCRIPTION
I attempted to add a piece of code that will make error output more nice by default, unless a `--stack` flag is provided...

I'm at school currently (our laptops have restrictions) so I cannot test it right now unfortunately.  I will run tests when I get home (however it might be a while, because I'm doing things after school as well)...  I thought I would open up a PR regardless in case someone wanted to do tests in the mean time.

#29 related.
