### PR TITLE
Add license to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,8 @@
   , "author": "TJ Holowaychuk <tj@vision-media.ca>"
   , "preferGlobal": true
   , "homepage": "https://github.com/tj/serve"
-  , "repository": {
-      "type": "git"
-    , "url": "https://github.com/tj/serve.git"
-  }
+  , "repository": "tj/serve"
+  , "license": "MIT"
   , "dependencies": {
       "connect": "2.3.x"
     , "stylus": "*"


### PR DESCRIPTION
Fix the npm warning:
```
npm WARN package.json serve@1.4.0 No license field.
```