### PR TITLE
Clickable link when ready

### DIFF
--- a/bin/serve
+++ b/bin/serve
@@ -235,6 +235,7 @@ function launch (port) {
   return server.listen(port, function () {
     // Successful message
     console.log('\033[90mServing \033[36m%s\033[90m on port \033[96m%d\033[0m', path, port);
+    console.log('\nAvailable on: \033[36mhttp://127.0.0.1:' + port + '\033[90m');
 
     // open the browser window to this server
     program.open && open('http://127.0.0.1:' + port);


### PR DESCRIPTION
Some terminals (such as the macOS one) allow the user to click on links displayed on them.
This PR adds a "Available on: http://127.0.0.1:<port\>" when the user runs `serve`, for convenience. 